### PR TITLE
Fix bug with undefined 'result' in main.py

### DIFF
--- a/soundclouddownloader/main.py
+++ b/soundclouddownloader/main.py
@@ -210,11 +210,11 @@ def main() -> None:
     zip_file = downloader.download_playlist(
         playlist_url, output_dir, max_workers=3, should_zip=should_zip
     )
-    if result:
+    if zip_file:
         if should_zip:
-            logger.success(f"Playlist downloaded and zipped: {result}")
+            logger.success(f"Playlist downloaded and zipped: {zip_file}")
         else:
-            logger.success(f"Playlist downloaded to directory: {result}")
+            logger.success(f"Playlist downloaded to directory: {zip_file}")
     else:
         logger.error("Failed to download playlist.")
     sys.stdout.flush()


### PR DESCRIPTION
## Description
Fixed a bug in main.py where the result variable was used without being defined, causing a NameError during logging. The fix updates the code to use the correct zip_file variable, which holds the path of the downloaded (and optionally zipped) playlist.

## Motivation and Context
This change fixes a runtime error that occurred when the program tried to log the download result using an undefined result variable. The bug prevented successful playlist downloads from being properly reported to the user. Updating it to use the correct zip_file variable ensures the script runs smoothly and logs accurate success messages.

## How Has This Been Tested?
Manually tested by running the downloader with both zipped and non-zipped output options. Verified that playlists are downloaded correctly, no errors are raised, and success messages are logged as expected. Also confirmed that the correct path (either folder or ZIP file) is shown in the logs without any NameErrors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes do not introduce any new linting errors or warnings.
- [x] I have checked that my changes are compatible with the project's target Python version(s).

## Additional Information
<!--- Any additional information, configuration or data that might be necessary to reproduce the issue. -->