### PR TITLE
Skip unextractable tracks instead of aborting whole playlist

### DIFF
--- a/soundclouddownloader/main.py
+++ b/soundclouddownloader/main.py
@@ -112,18 +112,42 @@ class SoundCloudDownloader:
 
         Returns:
             Playlist: A Playlist object containing the playlist information.
+
+        Notes:
+            Uses yt-dlp's ``ignoreerrors=True`` so a single track that yt-dlp
+            cannot extract (e.g. tracks affected by the upstream SoundCloud
+            issue https://github.com/yt-dlp/yt-dlp/issues/16603) does not
+            abort the whole playlist. Failed entries come back as ``None``
+            and are filtered out below.
         """
-        with yt_dlp.YoutubeDL(self.ydl_opts) as ydl:
+        playlist_opts = dict(self.ydl_opts)
+        playlist_opts["ignoreerrors"] = True
+
+        with yt_dlp.YoutubeDL(playlist_opts) as ydl:
             playlist_info = ydl.extract_info(playlist_url, download=False)
-            tracks = [
-                Track(
-                    id=track["id"],
-                    title=track["title"],
-                    artist=track["uploader"],
-                    url=track["webpage_url"],
+            entries = playlist_info.get("entries") or []
+            tracks: List[Track] = []
+            skipped = 0
+            for entry in entries:
+                if entry is None:
+                    skipped += 1
+                    continue
+                tracks.append(
+                    Track(
+                        id=entry["id"],
+                        title=entry["title"],
+                        artist=entry["uploader"],
+                        url=entry["webpage_url"],
+                    )
                 )
-                for track in playlist_info["entries"]
-            ]
+            if skipped:
+                logger.warning(
+                    f"Skipped {skipped} track(s) that yt-dlp could not extract. "
+                    "This is likely the upstream SoundCloud issue tracked at "
+                    "https://github.com/yt-dlp/yt-dlp/issues/16603 "
+                    "(DRM-protected or newly-formatted tracks). "
+                    f"Continuing with {len(tracks)} extractable track(s)."
+                )
             return Playlist(
                 id=playlist_info["id"], title=playlist_info["title"], tracks=tracks
             )

--- a/tests/test_soundcloud_downloader.py
+++ b/tests/test_soundcloud_downloader.py
@@ -86,6 +86,42 @@ class TestSoundCloudDownloader(unittest.TestCase):
         self.assertEqual(result.tracks[0].title, "Track 1")
         self.assertEqual(result.tracks[1].artist, "Artist 2")
 
+    @patch("yt_dlp.YoutubeDL")
+    def test_get_playlist_info_skips_unextractable_entries(self, mock_yt_dlp):
+        # yt-dlp with ignoreerrors=True returns None entries for tracks
+        # it couldn't extract (e.g. upstream 404 / DRM-protected tracks).
+        # We should skip those and return the rest, not crash.
+        mock_ydl = MagicMock()
+        mock_yt_dlp.return_value.__enter__.return_value = mock_ydl
+        mock_ydl.extract_info.return_value = {
+            "id": "playlist123",
+            "title": "Mixed Playlist",
+            "entries": [
+                {
+                    "id": "track1",
+                    "title": "Track 1",
+                    "uploader": "Artist 1",
+                    "webpage_url": "https://soundcloud.com/track1",
+                },
+                None,  # yt-dlp couldn't extract this one
+                {
+                    "id": "track3",
+                    "title": "Track 3",
+                    "uploader": "Artist 3",
+                    "webpage_url": "https://soundcloud.com/track3",
+                },
+            ],
+        }
+
+        result = self.downloader.get_playlist_info(
+            "https://soundcloud.com/test_playlist"
+        )
+
+        self.assertIsInstance(result, Playlist)
+        self.assertEqual(len(result.tracks), 2)
+        self.assertEqual(result.tracks[0].id, "track1")
+        self.assertEqual(result.tracks[1].id, "track3")
+
     @patch("soundclouddownloader.SoundCloudDownloader.get_playlist_info")
     @patch("soundclouddownloader.SoundCloudDownloader.download_track")
     def test_download_playlist(self, mock_download_track, mock_get_playlist_info):


### PR DESCRIPTION
Fixes #55.

## Root cause

The 404 the reporter hit is upstream. SoundCloud is rolling out DRM on a subset of tracks, and their API returns 404 to non-authorized clients asking for the format-info endpoint of a DRM-protected track. yt-dlp issue [#16603](https://github.com/yt-dlp/yt-dlp/issues/16603) was closed with confirmation it is DRM, and yt-dlp PR [#16602](https://github.com/yt-dlp/yt-dlp/pull/16602) is just an error-message improvement (lands in the next stable). `scdl` is broken for the same reason. We cannot extract DRM-protected tracks. That is not a bug anyone is going to "fix" without doing DRM circumvention, which yt-dlp policy bans.

## What this PR actually fixes

There was still a real bug on our side that #55 exposed: a single unextractable track aborted the entire playlist. The reporter explicitly noted some songs still work. They were all getting dropped because one DRM track raised early.

`get_playlist_info` now:
- passes `ignoreerrors=True` (in a separate options dict so per-track download behavior is unchanged),
- filters `None` entries that yt-dlp returns for skipped extractions,
- logs a warning naming the upstream DRM issue so the user knows why some tracks are missing.

## Test

Added `test_get_playlist_info_skips_unextractable_entries`. It feeds a mock playlist with one `None` entry and asserts the other two tracks survive and IDs are correct. Fails against old code with `TypeError: 'NoneType' object is not subscriptable`, passes after the fix.

Full suite: 7/7 pass (`uv run python -m unittest discover tests`).
